### PR TITLE
introduce capture destination option

### DIFF
--- a/builder/powervs/builder.go
+++ b/builder/powervs/builder.go
@@ -53,8 +53,10 @@ func (b *Builder) Prepare(raws ...interface{}) (generatedVars []string, warnings
 	}
 
 	packer.LogSecretFilter.Set(b.config.APIKey)
-	packer.LogSecretFilter.Set(b.config.Capture.COS.AccessKey)
-	packer.LogSecretFilter.Set(b.config.Capture.COS.SecretKey)
+	if b.config.Capture.COS != nil {
+		packer.LogSecretFilter.Set(b.config.Capture.COS.AccessKey)
+		packer.LogSecretFilter.Set(b.config.Capture.COS.SecretKey)
+	}
 
 	return []string{}, nil, nil
 }

--- a/builder/powervs/common/run_config.go
+++ b/builder/powervs/common/run_config.go
@@ -25,8 +25,11 @@ type StockImage struct {
 }
 
 type Capture struct {
-	Name string      `mapstructure:"name" required:"true"`
-	COS  *CaptureCOS `mapstructure:"cos" required:"false"`
+	Name string `mapstructure:"name" required:"true"`
+	// The destination determines how the image is captured. Options: ('image-catalog', 'cloud-storage', 'both'). The default is 'cloud-storage'.
+	// if image-catalog is specified then cos field content will be ignored
+	Destination string      `mapstructure:"destination" required:"false"`
+	COS         *CaptureCOS `mapstructure:"cos" required:"false"`
 }
 
 type CaptureCOS struct {

--- a/builder/powervs/common/run_config.hcl2spec.go
+++ b/builder/powervs/common/run_config.hcl2spec.go
@@ -37,8 +37,9 @@ func (*FlatCOS) HCL2Spec() map[string]hcldec.Spec {
 // FlatCapture is an auto-generated flat version of Capture.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatCapture struct {
-	Name *string         `mapstructure:"name" required:"true" cty:"name" hcl:"name"`
-	COS  *FlatCaptureCOS `mapstructure:"cos" required:"false" cty:"cos" hcl:"cos"`
+	Name        *string         `mapstructure:"name" required:"true" cty:"name" hcl:"name"`
+	Destination *string         `mapstructure:"destination" required:"false" cty:"destination" hcl:"destination"`
+	COS         *FlatCaptureCOS `mapstructure:"cos" required:"false" cty:"cos" hcl:"cos"`
 }
 
 // FlatMapstructure returns a new FlatCapture.
@@ -53,8 +54,9 @@ func (*Capture) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec 
 // The decoded values from this spec will then be applied to a FlatCapture.
 func (*FlatCapture) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"name": &hcldec.AttrSpec{Name: "name", Type: cty.String, Required: false},
-		"cos":  &hcldec.BlockSpec{TypeName: "cos", Nested: hcldec.ObjectSpec((*FlatCaptureCOS)(nil).HCL2Spec())},
+		"name":        &hcldec.AttrSpec{Name: "name", Type: cty.String, Required: false},
+		"destination": &hcldec.AttrSpec{Name: "destination", Type: cty.String, Required: false},
+		"cos":         &hcldec.BlockSpec{TypeName: "cos", Nested: hcldec.ObjectSpec((*FlatCaptureCOS)(nil).HCL2Spec())},
 	}
 	return s
 }

--- a/docs-partials/builder/powervs/common/Capture-not-required.mdx
+++ b/docs-partials/builder/powervs/common/Capture-not-required.mdx
@@ -1,5 +1,8 @@
 <!-- Code generated from the comments of the Capture struct in builder/powervs/common/run_config.go; DO NOT EDIT MANUALLY -->
 
+- `destination` (string) - The destination determines how the image is captured. Options: ('image-catalog', 'cloud-storage', 'both'). The default is 'cloud-storage'.
+  if image-catalog is specified then cos field content will be ignored
+
 - `cos` (\*CaptureCOS) - COS
 
 <!-- End of code generated from the comments of the Capture struct in builder/powervs/common/run_config.go; -->

--- a/docs-partials/builder/powervs/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/powervs/common/RunConfig-not-required.mdx
@@ -1,0 +1,7 @@
+<!-- Code generated from the comments of the RunConfig struct in builder/powervs/common/run_config.go; DO NOT EDIT MANUALLY -->
+
+- `subnet_ids` ([]string) - Subnet I Ds
+
+- `dhcp_network` (bool) - DHCP Network
+
+<!-- End of code generated from the comments of the RunConfig struct in builder/powervs/common/run_config.go; -->


### PR DESCRIPTION
This PR supports the different options for capture destinations

following new field is been added to the `capture` filed

`destination` (string) - The destination determines how the image is captured. Options: ('image-catalog', 'cloud-storage', 'both'). The default is 'cloud-storage'.
  if image-catalog is specified then cos field content will be ignored


e.g:

```json
....
    "builders": [
        {
            "type": "powervs",
....
.....
            "capture": {
                "name": "target-image-1",
                "destination": "image-catalog"
            }
        }
    ],
.....
```

post this run, you will see something like below:

```
$ ibmcloud pi image ls
ID                                     Name              Address
85c30fc5-2d25-4b40-95b5-932201bacc65   CentOS-Stream-9   /pcloud/v1/cloud-instances/e943af9c58c04143a7035c52b6d27c16/images/85c30fc5-2d25-4b40-95b5-932201bacc65
f1eb1728-72e9-4b2f-9a01-62756a264d56   target-image-1    /pcloud/v1/cloud-instances/e943af9c58c04143a7035c52b6d27c16/images/f1eb1728-72e9-4b2f-9a01-62756a264d56
```