### PR TITLE
powervs: validate discovered host IP before SSH connection

### DIFF
--- a/builder/powervs/common/ssh.go
+++ b/builder/powervs/common/ssh.go
@@ -3,6 +3,8 @@ package common
 import (
 	"errors"
 	"fmt"
+	"net"
+	"strings"
 	"time"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -42,7 +44,11 @@ func SSHHost() func(multistep.StateBag) (string, error) {
 					host = net.ExternalIP
 				}
 			}
-			if host != "" {
+			// Validate that the discovered host value is a valid IP address
+			// before attempting SSH. Invalid values fall back to DHCP lease
+			// discovery.
+			host = strings.TrimSpace(host)
+			if net.ParseIP(host) != nil {
 				return host, nil
 			}
 


### PR DESCRIPTION
## What this PR does

Validates that the discovered host value is a valid IP address before using it for SSH host selection.

## Problem

During DHCP-based PowerVS image builds, the PowerVS API returned a whitespace-only value (`" "`) for the instance IP while a valid DHCP lease already existed.

The current implementation accepts any non-empty string as a valid host:

```go
if host != "" {
    return host, nil
}
```

As a result, whitespace-only or otherwise invalid values are treated as valid hosts and returned immediately. This prevents the code from falling back to the DHCP lease lookup path, causing SSH connectivity failures even though a valid DHCP lease exists.

## Fix

Validate that the discovered host value is a valid IP address before using it:

```go
host = strings.TrimSpace(host)

if net.ParseIP(host) != nil {
    return host, nil
}
```

Invalid values now fall back to the existing DHCP lease discovery logic.

## Validation

Validated using a DHCP-backed PowerVS image build.

Before the change:

* Instance successfully obtained a DHCP lease.
* DHCP service reported a valid lease and MAC address mapping.
* Plugin received a whitespace-only value for the instance IP.
* SSH host discovery bypassed DHCP lease lookup and failed to connect.

After the change:

* Invalid host values are ignored.
* DHCP lease lookup path is executed.
* Plugin successfully discovers the lease IP.
* SSH connection succeeds and provisioning continues normally.

## Impact

This change is backward compatible.

* Valid IPv4 and IPv6 addresses continue to be accepted.
* Invalid values such as empty strings and whitespace-only strings are rejected.
* Existing DHCP lease fallback behavior is preserved.
